### PR TITLE
#16 pirate rolls

### DIFF
--- a/galaxytrucker.game.php
+++ b/galaxytrucker.game.php
@@ -36,7 +36,8 @@ $swdNamespaceAutoloadNamespace = function ($class) {
 };
 spl_autoload_register($swdNamespaceAutoloadNamespace, true, true);
 
-function autoload($class) {
+function autoload($class)
+{
   $file = dirname(__FILE__) . '/modules/' . $class . '.php';
   if (file_exists($file)) {
     require_once $file;

--- a/galaxytrucker.js
+++ b/galaxytrucker.js
@@ -1846,7 +1846,8 @@ define([
         'overall_player_board_' + notif.args.player_id,
         1500,
       );
-      this.playerGaveUp = true;
+      if (this.player_id == notif.args.player_id)
+        this.playerGaveUp = true;
     },
 
     notif_gainContent: function (notif) {
@@ -1880,9 +1881,16 @@ define([
 
     notif_hazardDiceRoll: function (notif) {
       console.log('notif_hazardDiceRoll', notif.args);
-      // if there's not a player_id then this applies to all players
-      // if there is a player_id, only use this for the active player
-      let isCurPlayer = notif.args.player_id === undefined || notif.args.player_id == this.player_id;
+      // if there's no player_ids then this applies to all players
+      // if there is a player_ids, only place hazard if the active player is in player_ids 
+      let isCurPlayer = false;
+      if (notif.args.player_ids === null || notif.args.player_ids === undefined) {
+        console.log('null/undefined player_id, not rendering hazard sprite');
+      }
+      else if (notif.args.player_ids.includes(this.player_id)) {
+        isCurPlayer = true;
+      }
+
       this.card.notif_hazardDiceRoll(notif.args, isCurPlayer, this.playerGaveUp);
     },
 

--- a/modules/Cards/CombatZone.php
+++ b/modules/Cards/CombatZone.php
@@ -2,8 +2,9 @@
 namespace GT\Cards;
 
 use GT\Models\EventCard;
+use GT\Models\HazardCard;
 
-class CombatZone extends EventCard
+class CombatZone extends EventCard implements HazardCard
 {
   private $lines;
 
@@ -15,14 +16,15 @@ class CombatZone extends EventCard
     $this->lines = $params['lines'];
   }
 
-  public function getCurrentHazard($progress)
+  public function getCurrentHazard($idx = null)
   {
     // TODO: Remove hardcoded value. Maybe introduce a parameter isPenaltyShot and rely on it. Anyway hardcode is evil
     $penalty = $this->lines[3]['penalty_value'];
-    if ($progress) {
-      return $penalty[$progress];
+    if ($idx === null) {
+      return $penalty;
     }
-    return $penalty;
+
+    return array_key_exists($idx, $penalty) ? $penalty[$idx] : null;
   }
 
   static $instances = [
@@ -50,7 +52,11 @@ class CombatZone extends EventCard
       'lines' => [
         1 => ['criterion' => 'crew', 'penalty_type' => 'goods', 'penalty_value' => 4],
         2 => ['criterion' => 'cannons', 'penalty_type' => 'crew', 'penalty_value' => 4],
-        3 => ['criterion' => 'engines', 'penalty_type' => 'shot', 'penalty_value' => ['s90', 's270', 's0', 's0', 'b180', 'b180']],
+        3 => [
+          'criterion' => 'engines',
+          'penalty_type' => 'shot',
+          'penalty_value' => ['s90', 's270', 's0', 's0', 'b180', 'b180'],
+        ],
       ],
     ],
   ];

--- a/modules/Cards/MeteoricSwarm.php
+++ b/modules/Cards/MeteoricSwarm.php
@@ -2,8 +2,9 @@
 namespace GT\Cards;
 
 use GT\Models\EventCard;
+use GT\Models\HazardCard;
 
-class MeteoricSwarm extends EventCard
+class MeteoricSwarm extends EventCard implements HazardCard
 {
   private $meteors;
 
@@ -15,12 +16,12 @@ class MeteoricSwarm extends EventCard
     $this->meteors = $params['meteors'];
   }
 
-  public function getCurrentHazard($progress = null)
+  public function getCurrentHazard($idx = null)
   {
-    if ($progress === null) {
+    if ($idx === null) {
       return $this->meteors;
     }
-    return $this->meteors[$progress];
+    return array_key_exists($idx, $this->meteors) ? $this->meteors[$idx] : null;
   }
 
   static $instances = [

--- a/modules/Cards/Pirates.php
+++ b/modules/Cards/Pirates.php
@@ -22,7 +22,8 @@ class Pirates extends HazardCard
 
   public function applyPenalty($game, $player)
   {
-    return 'cannonBlasts';
+    GT_DBPlayer::setCardChoice($game, $player['player_id'], CARD_CHOICE_APPLY_HAZARD);
+    return;
   }
 
   public function giveReward($game, $player)

--- a/modules/Cards/Pirates.php
+++ b/modules/Cards/Pirates.php
@@ -33,6 +33,11 @@ class Pirates extends HazardCard
     \GT_DBPlayer::setCardAllDone($game, $player['player_id']);
   }
 
+  public function finishCard($game)
+  {
+    return 'cannonBlasts';
+  }
+
   static $instances = [
     [
       'id' => 2,

--- a/modules/Cards/Pirates.php
+++ b/modules/Cards/Pirates.php
@@ -1,9 +1,10 @@
 <?php
 namespace GT\Cards;
 
+use GT\Models\EnemyCard;
 use GT\Models\HazardCard;
 
-class Pirates extends HazardCard
+class Pirates extends EnemyCard implements HazardCard
 {
   public function __construct($params)
   {
@@ -12,17 +13,18 @@ class Pirates extends HazardCard
     $this->name = clienttranslate('Pirates');
   }
 
-  public function getCurrentHazard($progress = null)
+  public function getCurrentHazard($idx = null)
   {
-    if ($progress === null) {
+    if ($idx === null) {
       return $this->enemy_penalty;
     }
-    return $this->enemy_penalty[$progress];
+
+    return array_key_exists($idx, $this->enemy_penalty) ? $this->enemy_penalty[$idx] : null;
   }
 
   public function applyPenalty($game, $player)
   {
-    GT_DBPlayer::setCardChoice($game, $player['player_id'], CARD_CHOICE_APPLY_HAZARD);
+    \GT_DBPlayer::setCardChoice($game, $player['player_id'], CARD_CHOICE_APPLY_HAZARD);
     return;
   }
 

--- a/modules/Cards/Slavers.php
+++ b/modules/Cards/Slavers.php
@@ -1,9 +1,9 @@
 <?php
 
 namespace GT\Cards;
-use GT\Models\HazardCard;
+use GT\Models\EnemyCard;
 
-class Slavers extends HazardCard
+class Slavers extends EnemyCard
 {
   public function __construct($params)
   {

--- a/modules/Cards/Smugglers.php
+++ b/modules/Cards/Smugglers.php
@@ -1,9 +1,9 @@
 <?php
 namespace GT\Cards;
 
-use GT\Models\HazardCard;
+use GT\Models\EnemyCard;
 
-class Smugglers extends HazardCard
+class Smugglers extends EnemyCard
 {
   public function __construct($params)
   {

--- a/modules/GT_ActionsCard.php
+++ b/modules/GT_ActionsCard.php
@@ -69,7 +69,10 @@ class GT_ActionsCard extends APP_GameClass
 
     $nextState = $card->loseContent($game, $playerId, $typeToLose);
     if ($nextState == null) {
-      $game->throw_bug_report_dump("loseContentChoice wrong card type for cardId {$card->getId()}, type to lose - {$typeToLose}", $card);
+      $game->throw_bug_report_dump(
+        "loseContentChoice wrong card type for cardId {$card->getId()}, type to lose - {$typeToLose}",
+        $card
+      );
     }
 
     GT_DBPlayer::setCardDone($game, $playerId);
@@ -106,9 +109,13 @@ class GT_ActionsCard extends APP_GameClass
 
   function powerDefense($game, $plId, $card, $battChoices, $defenseType)
   {
+    $game->dump_var(
+      "powerDefense ($defenseType) for player $plId against card {$card->getId()} with choices",
+      $battChoices
+    );
     // Powering shields or cannons against incoming cannon or meteors
     if (count($battChoices) == 0) {
-      GT_Hazards::hazardDamage($game, $plId, $card);
+      (new GT_Hazards($game, $card))->hazardDamage($plId);
     } else {
       $player = GT_DBPlayer::getPlayer($game, $plId);
       if ($defenseType == 'shields') {
@@ -127,8 +134,10 @@ class GT_ActionsCard extends APP_GameClass
       $plyrContent->checkBattChoices($battChoices, 1);
       $plyrContent->loseContent($battChoices, 'cell');
 
-      GT_Hazards::hazardHarmless($game, $player, $msg, $card);
+      (new GT_Hazards($game, $card))->hazardHarmless($player, $msg);
     }
+
+    GT_DBPlayer::setCardDone($game, $plId);
   }
 
   function powerCannonsEnemy($game, $plId, $card, $battChoices)

--- a/modules/GT_DBPlayer.php
+++ b/modules/GT_DBPlayer.php
@@ -65,9 +65,16 @@ class GT_DBPlayer extends APP_GameClass
     $game->DbQuery("UPDATE player SET still_flying = 0, player_position = null WHERE player_id = $plId");
   }
 
-  function clearCardProgress($game)
+  function resetCard($game)
   {
     $game->DbQuery('UPDATE player SET card_line_done=0, card_action_choice=0');
+  }
+
+  function resetCardProgress($game, $plId = null)
+  {
+    $where = $plId ? "WHERE player_id = $plId" : '';
+
+    $game->DbQuery("UPDATE player SET card_line_done=0 $where");
   }
 
   function setCardChoice($game, $plId, $choice)
@@ -94,7 +101,7 @@ class GT_DBPlayer extends APP_GameClass
 
   function setCardAllDone($game)
   {
-    $game->DbQuery('UPDATE player SET card_line_done=2');
+    $game->DbQuery('UPDATE player SET card_line_done=2, card_action_choice=0');
   }
 
   function setCardInProgress($game, $plId)

--- a/modules/GT_Enemy.php
+++ b/modules/GT_Enemy.php
@@ -1,6 +1,6 @@
 <?php
 
-use GT\Models\HazardCard;
+use GT\Models\EnemyCard;
 
 class GT_Enemy extends APP_GameClass
 {
@@ -49,27 +49,26 @@ class GT_Enemy extends APP_GameClass
 
   function fightIsTie()
   {
-    $this->game->notifyAllPlayers('onlyLogMessage', clienttranslate('${player_name} fights ${type} to a draw'), [
+    $this->game->notifyAllPlayers('onlyLogMessage', clienttranslate('${player_name} fights ${name} to a draw'), [
       'player_name' => $this->player['player_name'],
-      'type' => $this->card->getType(),
+      'name' => $this->card->getName(),
     ]);
     return null;
   }
 
   function giveReward()
   {
-    $cardType = $this->card->getType();
     // based on type of card give the correct reward and return the needed state
-    $this->game->notifyAllPlayers('onlyLogMessage', clienttranslate('${player_name} defeats ${type} in battle'), [
+    $this->game->notifyAllPlayers('onlyLogMessage', clienttranslate('${player_name} defeats ${name} in battle'), [
       'player_name' => $this->player['player_name'],
-      'type' => $cardType,
+      'name' => $this->card->getName(),
     ]);
 
     $nextState = null;
-    if ($this->card instanceof HazardCard) {
+    if ($this->card instanceof EnemyCard) {
       $nextState = $this->card->giveReward($this->game, $this->player);
     } else {
-      $this->game->throw_bug_report("Unknown card type ($cardType) in GT_Enemy::giveReward");
+      $this->game->throw_bug_report("Unknown card type ({$this->card->getType()}) in GT_Enemy::giveReward");
     }
     return $nextState;
   }
@@ -79,12 +78,12 @@ class GT_Enemy extends APP_GameClass
     // based on type of card, apply the penalty and return needed state
     $this->game->notifyAllPlayers(
       'onlyLogMessage',
-      clienttranslate('${player_name} is defeated by ${type} in battle'),
-      ['player_name' => $this->player['player_name'], 'type' => $this->card->getType()]
+      clienttranslate('${player_name} is defeated by ${name} in battle'),
+      ['player_name' => $this->player['player_name'], 'name' => $this->card->getName()]
     );
 
-    if ($this->card instanceof HazardCard) {
-      return $this->card->applyPenalty($ths->game, $this->player);
+    if ($this->card instanceof EnemyCard) {
+      return $this->card->applyPenalty($this->game, $this->player);
     } else {
       $this->game->throw_bug_report("Unknown card type ({$this->card->getType()}) in GT_Enemy::applyPenalty");
     }

--- a/modules/GT_Enemy.php
+++ b/modules/GT_Enemy.php
@@ -83,12 +83,10 @@ class GT_Enemy extends APP_GameClass
       ['player_name' => $this->player['player_name'], 'type' => $this->card->getType()]
     );
 
-    $game = $this->game;
-
     if ($this->card instanceof HazardCard) {
-      return $this->card->applyPenalty($game, $this->player);
+      return $this->card->applyPenalty($ths->game, $this->player);
     } else {
-      $game->throw_bug_report("Unknown card type ({$this->card->getType()}) in GT_Enemy::applyPenalty");
+      $this->game->throw_bug_report("Unknown card type ({$this->card->getType()}) in GT_Enemy::applyPenalty");
     }
   }
 }

--- a/modules/GT_Hazards.php
+++ b/modules/GT_Hazards.php
@@ -14,9 +14,9 @@ class GT_Hazards extends APP_GameClass
   {
     // Runs through all players in flight with card choice APPLY_HAZARD, for all hazards
     // Marks each player done for a hazard as cardDone
-    // When first entering this method (run resetCardProgressForNextHazard()):
-    //  * appropriate players card choice as APPLY_HAZARD
-    //  * card not done (card_line_done) for those players
+    // When first entering this method:
+    //  * set appropriate players card choice as APPLY_HAZARD
+    //  * set card not done (card_line_done) for those players (run resetCardProgressForNextHazard())
     $game = $this->game;
     $card = $this->card;
 

--- a/modules/GT_StatesCard.php
+++ b/modules/GT_StatesCard.php
@@ -22,7 +22,7 @@ class GT_StatesCard extends APP_GameClass
     return [
       'id' => $cardId,
       'type' => $card->getType(),
-      'curHazard' => GT_Hazards::getHazardRoll($game, $card),
+      'curHazard' => (new GT_Hazards($game, $card))->getHazardRoll(),
       'card_line_done' => GT_DBPlayer::getCardProgress($game),
     ];
   }
@@ -34,7 +34,9 @@ class GT_StatesCard extends APP_GameClass
     $cardOrderInFlight = $game->getGameStateValue('cardOrderInFlight');
     $cardOrderInFlight++;
     $game->setGameStateValue('cardOrderInFlight', $cardOrderInFlight);
-    $currentCardId = $game->getUniqueValueFromDB('SELECT card_id id FROM card ' . "WHERE card_order=$cardOrderInFlight");
+    $currentCardId = $game->getUniqueValueFromDB(
+      'SELECT card_id id FROM card ' . "WHERE card_order=$cardOrderInFlight"
+    );
 
     $game->setGameStateValue('cardArg1', -1);
     $game->setGameStateValue('cardArg2', -1);
@@ -46,7 +48,7 @@ class GT_StatesCard extends APP_GameClass
       $game->setGameStateValue('currentCard', NO_CARD);
     } else {
       $game->setGameStateValue('currentCard', $currentCardId);
-      GT_Hazards::resetHazardProgress($game);
+      (new GT_Hazards($game))->resetHazardProgress();
 
       // temp, so that there is an active player when going to notImpl state
       if ($game->getUniqueValueFromDB('SELECT global_value FROM global WHERE global_id=2') == 0) {
@@ -171,68 +173,19 @@ class GT_StatesCard extends APP_GameClass
     return 'nextCard';
   }
 
-  function stMeteoric($game) {
-    $cardId = $game->getGameStateValue('currentCard');
-    $card = $game->card[$cardId];
-    $players = GT_DBPlayer::getPlayersInFlight($game);
-
-    for ($players as $plId => $player) {
-      GT_DBPlayer::setCardChoice($game, $plId, CARD_CHOICE_APPLY_HAZARD);
-    }
-
-    $hazards = new GT_Hazards($game, $card);
-    $hazards->applyHazards();
-
-    return 'nextCard';
-  }
-
-  function stMeteoric_old($game)
+  function stMeteoric($game)
   {
     $cardId = $game->getGameStateValue('currentCard');
     $card = CardsManager::get($cardId);
+    $players = GT_DBPlayer::getPlayersInFlight($game);
 
-    $idx = $game->getGameStateValue('currentCardProgress');
-    if ($idx < 0) {
-      $idx = 0; // start of the card
-      GT_Hazards::nextHazard($game, 0);
+    foreach ($players as $plId => $player) {
+      GT_DBPlayer::setCardChoice($game, $plId, CARD_CHOICE_APPLY_HAZARD);
     }
 
-    $game->dump_var("Entering meteor with current card $cardId Meteor $idx.", $card);
-    while ($idx < count($card->getCurrentHazard())) {
-      $game->log("Running meteor $idx.");
-
-      // Get previous dice roll, if available. If not roll and notif
-      $hazResults = GT_Hazards::getHazardRoll($game, $card, $idx);
-
-      if ($hazResults['missed']) {
-        $game->notifyAllPlayers('hazardMissed', clienttranslate('Meteor missed all ships'), [
-          'hazResults' => $hazResults,
-        ]);
-        GT_Hazards::nextHazard($game, ++$idx);
-        continue;
-      }
-
-      // Go through players until finding one that has to act
-      $players = GT_DBPlayer::getPlayersForCard($game);
-      foreach ($players as $plId => $player) {
-        $game->log("stMeteoric for player $plId, index $idx.");
-        $nextState = GT_Hazards::applyHazardToShip($game, $hazResults, $player);
-        $game->log("Got $nextState");
-        if ($nextState) {
-          GT_DBPlayer::setCardInProgress($game, $plId);
-          $game->gamestate->changeActivePlayer($plId);
-          return $nextState;
-        }
-      }
-
-      $game->log("Finished index $idx");
-      // no players left to act for this hazard, go to next hazard
-      GT_Hazards::nextHazard($game, ++$idx);
-    }
-
-    // TODO hide dice (see how we're hiding cards)
-    return 'nextCard';
+    return (new GT_Hazards($game, $card))->applyHazards();
   }
+
 
   function stEnemy($game)
   {
@@ -243,6 +196,7 @@ class GT_StatesCard extends APP_GameClass
     $card = CardsManager::get($cardId);
 
     $players = GT_DBPlayer::getPlayersForCard($game);
+    $game->dump_var('players for card', $players);
     foreach ($players as $plId => $player) {
       $game->log("stEnemy for player $plId");
       $enemy = new GT_Enemy($game, $card, $player);
@@ -251,8 +205,8 @@ class GT_StatesCard extends APP_GameClass
       if (is_null($cannonPower)) {
         $game->notifyAllPlayers(
           'onlyLogMessage',
-          clienttranslate('${player_name} must decide whether to activate a cannon against ${type}'),
-          ['player_name' => $player['player_name'], 'type' => $card->getType()]
+          clienttranslate('${player_name} must decide whether to activate a cannon against ${name}'),
+          ['player_name' => $player['player_name'], 'name' => $card->getName()]
         );
         $nextState = 'powerCannons';
       } else {
@@ -265,64 +219,12 @@ class GT_StatesCard extends APP_GameClass
       return $nextState;
     }
 
-    $card->finishCard($game);
+    // Only reached here if no players returned from getPlayersForCard
+    $game->dump_var('Finished stEnemy for players', $players);
+    return $card->finishCard($game);
   }
 
-  function stCannonBlasts($game)
-  {
-    // In process of looping over all cannon blasts from combat or pirates card
-    $cardId = $game->getGameStateValue('currentCard');
-    $card = CardsManager::get($cardId);
 
-    $hazards = new GT_Hazard($game, $card);
-    $players = GT_DBPlayer::getPlayersForCard($game);
-
-    $player = GT_DBPlayer::getPlayerCardInProgress($game);
-
-    $idx = $game->getGameStateValue('currentCardProgress');
-    if ($idx < 0) {
-      $idx = 0; // start of the card
-      GT_Hazards::nextHazard($game, 0);
-    } else {
-      // Returning here from another state, move on to next hazard
-      $game->log("Finished index $idx");
-      GT_Hazards::nextHazard($game, ++$idx);
-    }
-
-    $game->dump_var("Entering cannon blasts with current card $cardId blast $idx.", $card);
-    $blasts = $card->getCurrentHazard();
-
-    while ($idx < count($blasts)) {
-      $game->dump_var("Running cannon blast $idx on player.", $player);
-      $nextState = null;
-
-      // Get a dice roll
-      $hazResults = GT_Hazards::getHazardRoll($game, $card, $idx);
-
-      if ($hazResults['missed']) {
-        $game->notifyAllPlayers('hazardMissed', clienttranslate('Cannon blast missed ${player_name}\'s ship'), [
-          'hazResults' => $hazResults,
-          'player_id' => $player['player_id'],
-          'player_name' => $player['player_name'],
-        ]);
-      } else {
-        $nextState = GT_Hazards::applyHazardToShip($game, $hazResults, $player);
-      }
-
-      if ($nextState) {
-        return $nextState;
-      }
-
-      $game->log("Finished index $idx");
-      GT_Hazards::nextHazard($game, ++$idx);
-    }
-
-    GT_Hazards::resetHazardProgress($game);
-    GT_DBPlayer::setCardDone($game, $player['player_id']);
-    return 'nextPlayerEnemy';
-  }
-
-  // ###################### HELPERS ##########################
 }
 
 ?>

--- a/modules/GT_StatesCard.php
+++ b/modules/GT_StatesCard.php
@@ -265,12 +265,7 @@ class GT_StatesCard extends APP_GameClass
       return $nextState;
     }
 
-    if ($card['type'] == 'pirates') {
-      return 'cannonBlasts';
-    } else {
-      GT_DBPlayer::setCardAllDone($game);
-      return 'nextCard';
-    }
+    $card->finishCard($game);
   }
 
   function stCannonBlasts($game)

--- a/modules/GT_TestGameState.php
+++ b/modules/GT_TestGameState.php
@@ -24,7 +24,7 @@ class GT_TestGameState
       CARD_COMBAT_ZONE => 0,
       CARD_ABANDONED_SHIP => 0,
       CARD_ABANDONED_STATION => 0,
-      ];
+    ];
   }
 
   function log($msg)
@@ -80,7 +80,7 @@ class GT_TestGameState
 
     // Usage: [CARD_PIRATES, CARD_PLANETS, CARD_SMUGGLERS] - they will appear in this order in the game
     // Unfortunately works a bit problematic with the same type given 2+ times
-    $cardsTypes = [CARD_COMBAT_ZONE, CARD_PIRATES, CARD_SMUGGLERS];
+    $cardsTypes = [CARD_COMBAT_ZONE, CARD_METEORIC_SWARM, CARD_PIRATES, CARD_SMUGGLERS];
     foreach (array_reverse($cardsTypes) as $card) {
       $this->setCardOrder($card);
     }

--- a/modules/Models/AbandonedCard.php
+++ b/modules/Models/AbandonedCard.php
@@ -2,7 +2,7 @@
 namespace GT\Models;
 
 /*
- * HazardCard: base class to describe event cards containing hazards
+ * AbandonedCard: base class to describe event cards containing abanonded events
  */
 class AbandonedCard extends EventCard
 {
@@ -10,20 +10,25 @@ class AbandonedCard extends EventCard
   protected $reward;
   protected $days_loss;
 
-  public function __construct($params) {
+  public function __construct($params)
+  {
     parent::__construct($params);
     $this->reward = $params['reward'];
     $this->crew = $params['crew'];
     $this->days_loss = $params['days_loss'];
   }
 
-  public function getCrew() {
+  public function getCrew()
+  {
     return $this->crew;
   }
 
-  public function getReward() {
+  public function getReward()
+  {
     return $this->reward;
   }
 
-  public function exploreChoice($game, $playerId) {}
+  public function exploreChoice($game, $playerId)
+  {
+  }
 }

--- a/modules/Models/EnemyCard.php
+++ b/modules/Models/EnemyCard.php
@@ -1,0 +1,50 @@
+<?php
+namespace GT\Models;
+
+/*
+ * EnemyCard: base class to describe event cards containing enemies
+ */
+class EnemyCard extends EventCard
+{
+  protected $enemy_strength;
+  protected $enemy_penalty;
+  protected $reward;
+  protected $days_loss;
+
+  protected $flightBoard;
+
+  public function __construct($params)
+  {
+    parent::__construct($params);
+    $this->enemy_strength = $params['enemy_strength'];
+    $this->enemy_penalty = $params['enemy_penalty'];
+    $this->reward = $params['reward'];
+    $this->days_loss = $params['days_loss'];
+  }
+
+  public function getEnemyStrength()
+  {
+    return $this->enemy_strength;
+  }
+
+  public function getReward()
+  {
+    return $this->reward;
+  }
+
+  public function applyPenalty($game, $player)
+  {
+  }
+
+  public function giveReward($game, $player)
+  {
+    $this->flightBoard = $game->newFlightBoard();
+    $this->flightBoard->moveShip($player['player_id'], -$this->days_loss);
+  }
+
+  public function finishCard($game)
+  {
+    \GT_DBPlayer::setCardAllDone($game);
+    return 'nextCard';
+  }
+}

--- a/modules/Models/HazardCard.php
+++ b/modules/Models/HazardCard.php
@@ -13,7 +13,8 @@ class HazardCard extends EventCard
 
   protected $flightBoard;
 
-  public function __construct($params) {
+  public function __construct($params)
+  {
     parent::__construct($params);
     $this->enemy_strength = $params['enemy_strength'];
     $this->enemy_penalty = $params['enemy_penalty'];
@@ -21,19 +22,29 @@ class HazardCard extends EventCard
     $this->days_loss = $params['days_loss'];
   }
 
-  public function getEnemyStrength() {
+  public function getEnemyStrength()
+  {
     return $this->enemy_strength;
   }
 
-  public function getReward() {
+  public function getReward()
+  {
     return $this->reward;
   }
 
-  public function applyPenalty($game, $player) {
+  public function applyPenalty($game, $player)
+  {
   }
 
-  public function giveReward($game, $player) {
+  public function giveReward($game, $player)
+  {
     $this->flightBoard = $game->newFlightBoard();
     $this->flightBoard->moveShip($player['player_id'], -$this->days_loss);
+  }
+
+  public function finishCard($game)
+  {
+    GB_DBPlayer::setCardAllDone($game);
+    return 'nextCard';
   }
 }

--- a/modules/Models/HazardCard.php
+++ b/modules/Models/HazardCard.php
@@ -2,49 +2,9 @@
 namespace GT\Models;
 
 /*
- * HazardCard: base class to describe event cards containing hazards
+ * HazardCard: interface for cards that have hazards
  */
-class HazardCard extends EventCard
+interface HazardCard
 {
-  protected $enemy_strength;
-  protected $enemy_penalty;
-  protected $reward;
-  protected $days_loss;
-
-  protected $flightBoard;
-
-  public function __construct($params)
-  {
-    parent::__construct($params);
-    $this->enemy_strength = $params['enemy_strength'];
-    $this->enemy_penalty = $params['enemy_penalty'];
-    $this->reward = $params['reward'];
-    $this->days_loss = $params['days_loss'];
-  }
-
-  public function getEnemyStrength()
-  {
-    return $this->enemy_strength;
-  }
-
-  public function getReward()
-  {
-    return $this->reward;
-  }
-
-  public function applyPenalty($game, $player)
-  {
-  }
-
-  public function giveReward($game, $player)
-  {
-    $this->flightBoard = $game->newFlightBoard();
-    $this->flightBoard->moveShip($player['player_id'], -$this->days_loss);
-  }
-
-  public function finishCard($game)
-  {
-    GB_DBPlayer::setCardAllDone($game);
-    return 'nextCard';
-  }
+  public function getCurrentHazard($progress = null);
 }

--- a/modules/constants.inc.php
+++ b/modules/constants.inc.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
-* Card types constants
-*/
+ * Card types constants
+ */
 define('NO_CARD', -1);
 define('CARD_SLAVERS', 0);
 define('CARD_SMUGGLERS', 1);
@@ -16,3 +16,5 @@ define('CARD_PLANETS', 8);
 define('CARD_COMBAT_ZONE', 9);
 define('CARD_ABANDONED_SHIP', 10);
 define('CARD_ABANDONED_STATION', 11);
+
+define('CARD_CHOICE_APPLY_HAZARD', 100);

--- a/states.inc.php
+++ b/states.inc.php
@@ -310,6 +310,7 @@ $machinestates = [
       'nextCard' => STATE_NOT_IMPL,
       'powerCannons' => STATE_POWER_CANNONS,
       'enemyResults' => STATE_ENEMY_RESULTS,
+      'cannonBlasts' => STATE_CANNON_BLASTS,
     ],
   ],
 
@@ -324,7 +325,6 @@ $machinestates = [
       'chooseCrew' => STATE_CHOOSE_CREW,
       'loseGoods' => STATE_LOSE_GOODS,
       'loseCells' => STATE_LOSE_CELLS,
-      'cannonBlasts' => STATE_CANNON_BLASTS,
       'placeGoods' => STATE_PLACE_GOODS,
       'nextPlayerEnemy' => STATE_ENEMY,
     ],
@@ -337,9 +337,10 @@ $machinestates = [
     'action' => 'stCannonBlasts',
     'updateGameProgression' => false,
     'transitions' => [
+      // "nextCard" => STATE_DRAW_CARD,
+      'nextCard' => STATE_NOT_IMPL,
       'shipDamage' => STATE_SHIP_DAMAGE,
       'powerShields' => STATE_POWER_SHIELDS,
-      'nextPlayerEnemy' => STATE_ENEMY,
     ],
   ],
 

--- a/states.inc.php
+++ b/states.inc.php
@@ -337,8 +337,7 @@ $machinestates = [
     'action' => 'stCannonBlasts',
     'updateGameProgression' => false,
     'transitions' => [
-      // "nextCard" => STATE_DRAW_CARD,
-      'nextCard' => STATE_NOT_IMPL,
+      'nextCard' => STATE_DRAW_CARD,
       'shipDamage' => STATE_SHIP_DAMAGE,
       'powerShields' => STATE_POWER_SHIELDS,
     ],


### PR DESCRIPTION
The main change is for pirates cards "penalty" to be marking players who lost to the pirates in the database as having lost (column `card_action_choice`). Then, when the pirates have been defeated or all players have faced them, the hazards are applied to players who lost. A new card method `finishCard` allows pirates to shift to the penalty phase and all other cards to draw the next card.

I was also able to combine the code for applying hazards from both meteors and pirates. The meteors is done similarly to how the pirates was accomplished - by setting the `card_action_choice` of all players still in flight to "lost".